### PR TITLE
Code cleanup and misc

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,4 +1,3 @@
-
 name: docker-push
 
 on:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ WORKDIR /app
 ADD . /app
 
 RUN apk add --no-cache git
-RUN yarn install
-ENTRYPOINT yarn start
+RUN yarn install --prod --frozen-lockfile
+ENTRYPOINT ["node", "/app/index.js"]

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ app.get('/:key', async (req, res) => {
       redisResp = await redisClient.hgetall(req.params.key);
   }
 
-  if (typeof redisResp !== 'object') {
+  if (typeof redisResp === 'string') {
     try {
       const jsonResp = JSON.parse(redisResp);
       res.json({

--- a/index.js
+++ b/index.js
@@ -1,144 +1,141 @@
-const express = require('express')
-const JSON = require('json-bigint')({ storeAsString: true });
-const app = express()
-const port = process.env.PORT || 3000;
-const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379/0'
-const secret = process.env.SECRET || "superscarysecret"
-
+const express = require('express');
 const redis = require('redis');
+const JSON = require('json-bigint')({ storeAsString: true });
 
-const redisClient = redis.createClient({
-    url: redisUrl
-});
+const port = process.env.PORT || 3000;
+const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379/0';
+const secret = process.env.SECRET || 'superscarysecret';
 
-redisClient.on('error', (err) => console.log('Redis Client Error', err));
+const app = express();
+const redisClient = redis.createClient({ url: redisUrl });
 
-redisClient.on('connect', function() {
-    console.log('Connected to redis!');
-});
+app.set('json spaces', 2);
 
+redisClient.on('error', (err) => console.log('Redis client error:', err));
+redisClient.on('connect', () => console.log('Connected to Redis!'));
 redisClient.connect();
 
-app.get("/teapot", async (req, res) => {
-    res.status(418).json({code: 418, message: "I'm a teapot."})
-})
-
-app.use(function(req, res, next) {
-    console.log(req.query)
-    if (req.headers.authorization != secret && req.query.secret != secret) {
-        return res.status(401).json({ code: 401, error: 'Unauthorized.' });
-    }
-    next();
+app.get('/teapot', (req, res) => {
+  res.status(418).json({ code: 418, message: "I'm a teapot." });
 });
 
-app.set('json spaces', 2)
+app.use((req, res, next) => {
+  console.log(req.query);
+  if (req.headers.authorization !== secret && req.query.secret !== secret) {
+    res.status(401).json({ code: 401, error: 'Unauthorized.' });
+    return;
+  }
+  next();
+});
 
-app.get("/", async (req, res) => {
-    res.setHeader('Content-Type', 'application/json');
-    res.status(403).json({
-        code: 403,
-        message: "GET / is not allowed."
-    })
-})
+app.get('/', (req, res) => {
+  res.status(403).json({
+    code: 403,
+    message: 'GET / is not allowed.'
+  });
+});
 
-app.get("/:key", async (req, res) => {
-    res.setHeader('Content-Type', 'application/json');
-    const keyType = await redisClient.type(req.params.key)
-    console.log(keyType)
-    let redisResp = null
-    if (keyType === "hash"){
-        redisResp = await redisClient.hGetAll(req.params.key)
-        
-        for (let key in redisResp){
-            try {
-                jsonResp = JSON.parse(redisResp[key])
-                redisResp[key] = jsonResp
-            } catch(e) {
-                // do nothing
-            }
-        }
-    }
-    else if (keyType == "none"){
-        res.status(404).json({
-            code: 404,
-            message: "Key does not exist or is null."
-        })
-        return
-    }
-    else if (keyType == "list"){
-        redisResp = await redisClient.lRange(req.params.key, 0, -1)
+app.get('/:key', async (req, res) => {
+  const keyType = await redisClient.type(req.params.key);
+  console.log(keyType);
+  let redisResp = null;
 
-        redisResp.forEach(function(value, index){
-            try {
-                jsonResp = JSON.parse(value)
-                redisResp[index] = jsonResp
-            } catch {
-                // leave as-is
-            }
-        })
-    }
-    else {
-        redisResp = await redisClient.hGetAll(req.params.key)    
-    }
+  switch (keyType) {
+    case 'none':
+      res.status(404).json({
+        code: 404,
+        message: 'Key does not exist or is null.'
+      });
+      return;
 
+    case 'hash':
+      redisResp = await redisClient.hGetAll(req.params.key);
+      redisResp.forEach((value, index) => {
+        try {
+          const jsonResp = JSON.parse(value);
+          redisResp[index] = jsonResp;
+        } catch {} // leave as-is
+      });
+      break;
+    case 'list':
+      redisResp = await redisClient.lRange(req.params.key, 0, -1);
+      redisResp.forEach((value, index) => {
+        try {
+          const jsonResp = JSON.parse(value);
+          redisResp[index] = jsonResp;
+        } catch {} // leave as-is
+      });
+      break;
+    case 'string':
+      redisResp = await redisClient.get(req.params.key);
+
+      try {
+        redisResp = JSON.parse(redisResp);
+      } catch {} // leave as-is
+      break;
+    default:
+      redisResp = await redisClient.hGetAll(req.params.key);
+  }
+
+  if (typeof redisResp !== 'object') {
     try {
-        jsonResp = JSON.parse(redisResp)
-        res.json({
-            code: 200,
-            data: jsonResp
-        })
-    } catch(e) {
-        res.json({
-            code: 200,
-            data: redisResp
-        })
-    }
-})
+      const jsonResp = JSON.parse(redisResp);
+      res.json({
+        code: 200,
+        data: jsonResp
+      });
+      return;
+    } catch {} // do nothing
+  }
+
+  res.json({
+    code: 200,
+    data: redisResp
+  });
+});
 
 app.get('/:key/:value', async (req, res) => {
-    res.setHeader('Content-Type', 'application/json');
-    const keyType = await redisClient.type(req.params.key)
-    
-    if (keyType != "hash"){
-        res.status(400).json({
-            code: 400,
-            message: "Bad request, key is not a hash and cannot be accessed like a hash. Try /:key."
-        })
-        return
+  const keyType = await redisClient.type(req.params.key);
+
+  if (keyType !== 'hash') {
+    res.status(400).json({
+      code: 400,
+      message: 'Bad request, key is not a hash and cannot be accessed like a hash. Try /:key.'
+    });
+    return;
+  }
+
+  const redisResp = await redisClient.hGet(req.params.key, req.params.value);
+
+  if (redisResp) {
+    try {
+      const jsonResp = JSON.parse(redisResp);
+      res.json({
+        code: 200,
+        data: jsonResp
+      });
+    } catch {
+      res.json({
+        code: 200,
+        data: redisResp
+      });
     }
-
-    const redisResp = await redisClient.hGet(req.params.key, req.params.value)
-
-    if (redisResp){
-        try {
-            jsonResp = JSON.parse(redisResp);
-            res.json({
-                "code": 200,
-                "data": jsonResp
-            })        
-        } catch(e) {
-            res.json({
-                "code": "200",
-                "data": redisResp
-            })
-        }
-    } else {
-        res.status(404).json({
-            "code": "404",
-            "message": "Key/value pair does not exist or is null."
-        })
-    }
-})
-
-app.get('*', function(req, res){
-    res.status(404).json({code: 404, message: "Path has no handler."});
+  } else {
+    res.status(404).json({
+      code: 404,
+      message: 'Key/value pair does not exist or is null.'
+    });
+  }
 });
 
-app.all('*', function(req, res){
-    res.status(405).json({code: 404, message: "Method not allowed."});
+app.get('*', (req, res) => {
+  res.status(404).json({ code: 404, message: 'Path has no handler.' });
 });
-  
+
+app.all('*', (req, res) => {
+  res.status(405).json({ code: 405, message: 'Method not allowed.' });
+});
 
 app.listen(port, () => {
-    console.log(`Listening on port ${port}`)
-})
+  console.log(`Listening on port ${port}`);
+});

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "license": "UNLICENSED",
   "dependencies": {
     "express": "^4.17.3",
-    "json-bigint": "https://github.com/sidorares/json-bigint.git#0ef9fc57063a5b52951529c2e631009753c493b9",
+    "json-bigint": "git+https://github.com/sidorares/json-bigint.git#0ef9fc57063a5b52951529c2e631009753c493b9",
     "redis": "^4.0.4"
   },
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "lint": "npx semistandard index.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "license": "UNLICENSED",
   "dependencies": {
-    "express": "^4.17.3",
+    "express": "4.17.3",
     "json-bigint": "git+https://github.com/sidorares/json-bigint.git#0ef9fc57063a5b52951529c2e631009753c493b9",
-    "redis": "^4.0.4"
+    "redis": "4.0.4"
   },
   "scripts": {
     "start": "node index.js",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "express": "4.17.3",
-    "json-bigint": "git+https://github.com/sidorares/json-bigint.git#0ef9fc57063a5b52951529c2e631009753c493b9",
-    "redis": "4.0.4"
+    "ioredis": "4.28.5",
+    "json-bigint": "git+https://github.com/sidorares/json-bigint.git#0ef9fc57063a5b52951529c2e631009753c493b9"
   },
   "scripts": {
     "start": "node index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,9 +232,9 @@ ipaddr.js@1.9.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
-"json-bigint@https://github.com/sidorares/json-bigint.git#0ef9fc57063a5b52951529c2e631009753c493b9":
+"json-bigint@git+https://github.com/sidorares/json-bigint.git#0ef9fc57063a5b52951529c2e631009753c493b9":
   version "1.0.0"
-  resolved "https://github.com/sidorares/json-bigint.git#0ef9fc57063a5b52951529c2e631009753c493b9"
+  resolved "git+https://github.com/sidorares/json-bigint.git#0ef9fc57063a5b52951529c2e631009753c493b9"
   dependencies:
     bignumber.js "^9.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,7 +140,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-express@^4.17.3:
+express@4.17.3:
   version "4.17.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.3.tgz#f6c7302194a4fb54271b73a1fe7a06478c8f85a1"
   integrity sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==
@@ -342,7 +342,7 @@ redis-parser@3.0.0:
   dependencies:
     redis-errors "^1.0.0"
 
-redis@^4.0.4:
+redis@4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/redis/-/redis-4.0.4.tgz#b567f82f59086df38433982f7f424b48e924ec7a"
   integrity sha512-KaM1OAj/nGrSeybmmOWSMY0LXTGT6FVWgUZZrd2MYzXKJ+VGtqVaciGQeNMfZiQX+kDM8Ke4uttb54m2rm6V0A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,41 +2,6 @@
 # yarn lockfile v1
 
 
-"@node-redis/bloom@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@node-redis/bloom/-/bloom-1.0.1.tgz#144474a0b7dc4a4b91badea2cfa9538ce0a1854e"
-  integrity sha512-mXEBvEIgF4tUzdIN89LiYsbi6//EdpFA7L8M+DHCvePXg+bfHWi+ct5VI6nHUFQE5+ohm/9wmgihCH3HSkeKsw==
-
-"@node-redis/client@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@node-redis/client/-/client-1.0.4.tgz#fe185750df3bcc07524f63fe8dbc8d14d22d6cbb"
-  integrity sha512-IM/NRAqg7MvNC3bIRQipXGrEarunrdgvrbAzsd3ty93LSHi/M+ybQulOERQi8a3M+P5BL8HenwXjiIoKm6ml2g==
-  dependencies:
-    cluster-key-slot "1.1.0"
-    generic-pool "3.8.2"
-    redis-parser "3.0.0"
-    yallist "4.0.0"
-
-"@node-redis/graph@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-redis/graph/-/graph-1.0.0.tgz#baf8eaac4a400f86ea04d65ec3d65715fd7951ab"
-  integrity sha512-mRSo8jEGC0cf+Rm7q8mWMKKKqkn6EAnA9IA2S3JvUv/gaWW/73vil7GLNwion2ihTptAm05I9LkepzfIXUKX5g==
-
-"@node-redis/json@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@node-redis/json/-/json-1.0.2.tgz#8ad2d0f026698dc1a4238cc3d1eb099a3bee5ab8"
-  integrity sha512-qVRgn8WfG46QQ08CghSbY4VhHFgaTY71WjpwRBGEuqGPfWwfRcIf3OqSpR7Q/45X+v3xd8mvYjywqh0wqJ8T+g==
-
-"@node-redis/search@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@node-redis/search/-/search-1.0.3.tgz#7c3d026bf994caf82019fd0c3924cfc09f041a29"
-  integrity sha512-rsrzkGWI84di/uYtEctS/4qLusWt0DESx/psjfB0TFpORDhe7JfC0h8ary+eHulTksumor244bXLRSqQXbFJmw==
-
-"@node-redis/time-series@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@node-redis/time-series/-/time-series-1.0.2.tgz#5dd3638374edd85ebe0aa6b0e87addc88fb9df69"
-  integrity sha512-HGQ8YooJ8Mx7l28tD7XjtB3ImLEjlUxG1wC1PAjxu6hPJqjPshUZxAICzDqDjtIbhDTf48WXXUcx8TQJB1XTKA==
-
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -76,7 +41,7 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-cluster-key-slot@1.1.0:
+cluster-key-slot@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
   integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
@@ -109,6 +74,18 @@ debug@2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^4.3.1:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
+denque@^1.1.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.1.tgz#07f670e29c9a78f8faecb2566a1e2c11929c5cbf"
+  integrity sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -199,11 +176,6 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-generic-pool@3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.8.2.tgz#aab4f280adb522fdfbdc5e5b64d718d3683f04e9"
-  integrity sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==
-
 http-errors@1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
@@ -227,6 +199,23 @@ inherits@2.0.4:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+ioredis@4.28.5:
+  version "4.28.5"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.28.5.tgz#5c149e6a8d76a7f8fa8a504ffc85b7d5b6797f9f"
+  integrity sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==
+  dependencies:
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.1"
+    denque "^1.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.flatten "^4.4.0"
+    lodash.isarguments "^3.1.0"
+    p-map "^2.1.0"
+    redis-commands "1.7.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -237,6 +226,21 @@ ipaddr.js@1.9.1:
   resolved "git+https://github.com/sidorares/json-bigint.git#0ef9fc57063a5b52951529c2e631009753c493b9"
   dependencies:
     bignumber.js "^9.0.0"
+
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -275,6 +279,11 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
 ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -291,6 +300,11 @@ on-finished@~2.3.0:
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
   dependencies:
     ee-first "1.1.1"
+
+p-map@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
 
 parseurl@~1.3.3:
   version "1.3.3"
@@ -330,29 +344,22 @@ raw-body@2.4.3:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-redis-errors@^1.0.0:
+redis-commands@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.7.0.tgz#15a6fea2d58281e27b1cd1acfb4b293e278c3a89"
+  integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
   integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
 
-redis-parser@3.0.0:
+redis-parser@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
   integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
   dependencies:
     redis-errors "^1.0.0"
-
-redis@4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/redis/-/redis-4.0.4.tgz#b567f82f59086df38433982f7f424b48e924ec7a"
-  integrity sha512-KaM1OAj/nGrSeybmmOWSMY0LXTGT6FVWgUZZrd2MYzXKJ+VGtqVaciGQeNMfZiQX+kDM8Ke4uttb54m2rm6V0A==
-  dependencies:
-    "@node-redis/bloom" "1.0.1"
-    "@node-redis/client" "1.0.4"
-    "@node-redis/graph" "1.0.0"
-    "@node-redis/json" "1.0.2"
-    "@node-redis/search" "1.0.3"
-    "@node-redis/time-series" "1.0.2"
 
 safe-buffer@5.2.1:
   version "5.2.1"
@@ -398,6 +405,11 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
+
 "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
@@ -430,8 +442,3 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
-
-yallist@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
- js style lints
  - Added `yarn lint` - using `semistandard`. (feel free to switch to `standard` if desired, since there was an inconsistency of with and without semicolons)
  - Use switch case instead of if/else if
  - Use Array.forEach() instead of `for const in`
  - Consistency between functions and arrow functions
  - Only try parsing Redis response if it isn't parsed already (aka. type `string`)
- Add `string` key support
- Removed application/json setHeader due to redundancy (express already deals with this)
- Misc inconsistencies fixed
- Switched from `node-redis` to `ioredis` (probably better performance, lower size)
- lock dependencies